### PR TITLE
Add support for multiple events within a single function

### DIFF
--- a/src/serverlessFunctions/parseFromTemplate.js
+++ b/src/serverlessFunctions/parseFromTemplate.js
@@ -2,7 +2,6 @@ import { join } from 'path';
 
 const isServerlessFunction = ({ Type }) => Type === 'AWS::Serverless::Function';
 const isApiEvent = ({ Type }) => Type.includes('Api');
-const hasApiEvent = ({ Properties }) => Object.values(Properties?.Events ?? {}).some(isApiEvent);
 
 const buildFnPathData = (path) => {
   const splittedPath = path.slice(1).split('/');
@@ -23,10 +22,15 @@ export default (template, envVars, portOffset, basePath) => {
 
   return Object.entries(template.Resources)
     // eslint-disable-next-line no-unused-vars
-    .filter(([_, resource]) => isServerlessFunction(resource) && hasApiEvent(resource))
+    .filter(([_, resource]) => isServerlessFunction(resource))
+    .flatMap(([name, resource]) => Object.values(resource.Properties?.Events ?? {})
+      .filter(isApiEvent)
+      .map((ApiEvent, i, apiEvents) => [
+        name + (apiEvents.length > 1 ? `_${i}` : ''),
+        { ApiEvent, ...resource },
+      ]))
     .reduce((result, [name, resource], i) => {
       const {
-        Events,
         Handler: handler = functionGlobals.Handler,
         Runtime: runtime = functionGlobals.Runtime,
         CodeUri: codeUri = functionGlobals.CodeUri,
@@ -34,8 +38,7 @@ export default (template, envVars, portOffset, basePath) => {
         Timeout: timeout = functionGlobals.Timeout,
       } = resource.Properties;
 
-      const apiEvent = Object.values(Events).find(isApiEvent);
-      const { Type, Properties: { Path, Method, PayloadFormatVersion } } = apiEvent;
+      const { Type, Properties: { Path, Method, PayloadFormatVersion } } = resource.ApiEvent;
 
       return result.concat({
         name,

--- a/tests/serverlessFunctions/parseFromTemplate.spec.js
+++ b/tests/serverlessFunctions/parseFromTemplate.spec.js
@@ -230,4 +230,60 @@ describe('parseFromTemplate()', () => {
 
     expect(functions[0].event.payloadFormatVersion).toEqual('2.0');
   });
+
+  it('should return functions with multiple events', () => {
+    const template = {
+      Resources: {
+        Greeting: {
+          Type: 'AWS::Serverless::Function',
+          Properties: {
+            CodeUri: './dist',
+            Handler: 'GreetHandler.default',
+            Runtime: 'nodejs12.x',
+            Events: {
+              APIWithName: {
+                Type: 'Api',
+                Properties: {
+                  Path: '/hello/byname/{name}',
+                  Method: 'GET',
+                },
+              },
+              APIAnonymous: {
+                Type: 'Api',
+                Properties: {
+                  Path: '/hello',
+                  Method: 'GET',
+                },
+              },
+            },
+          },
+        },
+        GetResources: {
+          Type: 'AWS::Serverless::Function',
+          Properties: {
+            CodeUri: './dist',
+            Handler: 'GetResourcesHandler.default',
+            Runtime: 'nodejs12.x',
+            Events: {
+              GetResourcesEvent: {
+                Type: 'Api',
+                Properties: {
+                  Path: '/resources',
+                  Method: 'GET',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const functions = parseFunctionsFromTemplate(template, envVars, portOffset, basePath);
+
+    expect(functions).toMatchObject([
+      { name: 'Greeting_0', containerPort: 3001, handler: 'GreetHandler.default' },
+      { name: 'Greeting_1', containerPort: 3002, handler: 'GreetHandler.default' },
+      { name: 'GetResources', containerPort: 3003, handler: 'GetResourcesHandler.default' },
+    ]);
+  });
 });


### PR DESCRIPTION
I have a use-case where a single serverless function responds to more than one event. This is sort of a workaround for the lack of optional path parameters:

```yaml
Resources:
  Greeting:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        APIWithName:
          Type: Api
          Properties:
            Path: /hello/byname/{name}
            Method: get
            RestApiId:
              Ref: ApiGatewayApi
        APIAnonymous:
          Type: Api
          Properties:
            Path: /hello
            Method: get
            RestApiId:
              Ref: ApiGatewayApi
      Handler: hello.handler
      CodeUri: ./dist/hello
```

This was not supported, but now it is :)