### PR TITLE
Adding an option for the value of port increment

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,6 +19,7 @@ program
   .option('--docker-network <dockerNetwork>', 'The docker network you want your containers to connect to')
   .option('--base-path <basePath>', 'The base path of the API', process.cwd())
   .option('--ref-overrides <refOverrides>', 'Comma-separated key=value pairs to use when resolving Ref calls in your function environments')
+  .option('--port-increment <portIncrement>', 'The increment value for ports that containers will use', '1')
   .action(async (apiName, options) => {
     await dockerService.validateDockerStatus();
 
@@ -29,6 +30,7 @@ program
       basePath,
       dockerNetwork,
       refOverrides,
+      portIncrement,
     } = options;
 
     const params = {
@@ -39,6 +41,7 @@ program
       basePath,
       dockerNetwork,
       refOverrides,
+      portIncrement: Number(portIncrement),
     };
 
     await startApi(dockerService, params);

--- a/src/index.js
+++ b/src/index.js
@@ -39,14 +39,20 @@ export default async (dockerService, options) => {
   const { template, envVars } = await getRequiredDependencies(options);
   const refOverrides = parseRefOverrides(options);
 
-  const { apiName, basePath, port } = options;
-  const portOffset = port + 1;
+  const {
+    apiName,
+    basePath,
+    port,
+    portIncrement,
+  } = options;
+  const portOffset = port + portIncrement;
   const functions = parseFunctionsFromTemplate(
     template,
     envVars,
     portOffset,
     basePath,
     refOverrides,
+    portIncrement,
   );
 
   await Promise.all([

--- a/src/serverlessFunctions/parseFromTemplate.js
+++ b/src/serverlessFunctions/parseFromTemplate.js
@@ -23,7 +23,7 @@ const buildFnPathData = (path) => {
   };
 };
 
-export default (template, envVars, portOffset, basePath, refOverrides = {}) => {
+export default (template, envVars, portOffset, basePath, refOverrides = {}, portIncrement = 1) => {
   const functionGlobals = template?.Globals?.Function ?? {};
 
   return Object.entries(template.Resources)
@@ -67,7 +67,7 @@ export default (template, envVars, portOffset, basePath, refOverrides = {}) => {
         },
         path: buildFnPathData(Path),
         method: Method.toLowerCase(),
-        containerPort: portOffset + i,
+        containerPort: portOffset + i * portIncrement,
         dockerImageWithTag: `lambci/lambda:${runtime}`,
         distPath: join(basePath, codeUri),
       });

--- a/tests/serverlessFunctions/parseFromTemplate.spec.js
+++ b/tests/serverlessFunctions/parseFromTemplate.spec.js
@@ -6,8 +6,9 @@ describe('parseFromTemplate()', () => {
       DB_NAME: 'my_database',
     },
   };
-  const portOffset = 3001;
+  const portOffset = 3010;
   const basePath = '/Users/foo/api';
+  const portIncrement = 10;
 
   it('should ignore resources that are not serverless functions', () => {
     const template = {
@@ -278,12 +279,19 @@ describe('parseFromTemplate()', () => {
       },
     };
 
-    const functions = parseFunctionsFromTemplate(template, envVars, portOffset, basePath);
+    const functions = parseFunctionsFromTemplate(
+      template,
+      envVars,
+      portOffset,
+      basePath,
+      {},
+      portIncrement,
+    );
 
     expect(functions).toMatchObject([
-      { name: 'Greeting_0', containerPort: 3001, handler: 'GreetHandler.default' },
-      { name: 'Greeting_1', containerPort: 3002, handler: 'GreetHandler.default' },
-      { name: 'GetResources', containerPort: 3003, handler: 'GetResourcesHandler.default' },
+      { name: 'Greeting_0', containerPort: 3010, handler: 'GreetHandler.default' },
+      { name: 'Greeting_1', containerPort: 3020, handler: 'GreetHandler.default' },
+      { name: 'GetResources', containerPort: 3030, handler: 'GetResourcesHandler.default' },
     ]);
   });
 
@@ -358,7 +366,7 @@ describe('parseFromTemplate()', () => {
     expect(functions).toMatchObject([
       {
         name: 'GetSomething',
-        containerPort: 3001,
+        containerPort: 3010,
         handler: 'GetSomethingHandler.default',
         environment: {
           ENVVAR_TOKEN_1: 'envVar_tok_one',


### PR DESCRIPTION
When running this SAM API proxy with multiple services, the ports for the generated containers are assigned automatically, and it often collides with the existing services. I'd like to add an `--port-increment` option(like 1000) to avoid collision.