### PR TITLE
test: linting create docker service spec

### DIFF
--- a/tests/docker/createDockerService.spec.js
+++ b/tests/docker/createDockerService.spec.js
@@ -1,5 +1,4 @@
 import { createDockerService } from '../../src/docker';
-import functions from '../fixtures/functions';
 
 describe('dockerService', () => {
   const apiName = 'test-api';


### PR DESCRIPTION
This `docker/createDockerService.spec.js` does not pass lint, so I've removed unnecessary definition out of it.