### PR TITLE
fix: envvars are well-injected on multiple events containers

### DIFF
--- a/src/serverlessFunctions/parseFromTemplate.js
+++ b/src/serverlessFunctions/parseFromTemplate.js
@@ -33,7 +33,7 @@ export default (template, envVars, portOffset, basePath, refOverrides = {}) => {
       .filter(isApiEvent)
       .map((ApiEvent, i, apiEvents) => [
         name + (apiEvents.length > 1 ? `_${i}` : ''),
-        { ApiEvent, ...resource },
+        { ApiEvent, OriginalName: name, ...resource },
       ]))
     .reduce((result, [name, resource], i) => {
       const {
@@ -51,7 +51,7 @@ export default (template, envVars, portOffset, basePath, refOverrides = {}) => {
         {
           ...functionGlobals.Environment?.Variables,
           ...resource.Properties.Environment?.Variables,
-          ...envVars[name],
+          ...envVars[resource.OriginalName],
         },
       );
 

--- a/src/serverlessFunctions/parseFromTemplate.js
+++ b/src/serverlessFunctions/parseFromTemplate.js
@@ -33,7 +33,7 @@ export default (template, envVars, portOffset, basePath, refOverrides = {}, port
       .filter(isApiEvent)
       .map((ApiEvent, i, apiEvents) => [
         name + (apiEvents.length > 1 ? `_${i}` : ''),
-        { ApiEvent, OriginalName: name, ...resource },
+        { ApiEvent, functionName: name, ...resource },
       ]))
     .reduce((result, [name, resource], i) => {
       const {
@@ -51,7 +51,7 @@ export default (template, envVars, portOffset, basePath, refOverrides = {}, port
         {
           ...functionGlobals.Environment?.Variables,
           ...resource.Properties.Environment?.Variables,
-          ...envVars[resource.OriginalName],
+          ...envVars[resource.functionName],
         },
       );
 

--- a/tests/serverlessFunctions/parseFromTemplate.spec.js
+++ b/tests/serverlessFunctions/parseFromTemplate.spec.js
@@ -5,6 +5,9 @@ describe('parseFromTemplate()', () => {
     GetSomething: {
       DB_NAME: 'my_database',
     },
+    Greeting: {
+      DB_NAME: 'my_greeting',
+    },
   };
   const portOffset = 3001;
   const basePath = '/Users/foo/api';
@@ -281,9 +284,23 @@ describe('parseFromTemplate()', () => {
     const functions = parseFunctionsFromTemplate(template, envVars, portOffset, basePath);
 
     expect(functions).toMatchObject([
-      { name: 'Greeting_0', containerPort: 3001, handler: 'GreetHandler.default' },
-      { name: 'Greeting_1', containerPort: 3002, handler: 'GreetHandler.default' },
-      { name: 'GetResources', containerPort: 3003, handler: 'GetResourcesHandler.default' },
+      {
+        name: 'Greeting_0',
+        containerPort: 3001,
+        handler: 'GreetHandler.default',
+        environment: { DB_NAME: 'my_greeting' },
+      },
+      {
+        name: 'Greeting_1',
+        containerPort: 3002,
+        handler: 'GreetHandler.default',
+        environment: { DB_NAME: 'my_greeting' },
+      },
+      {
+        name: 'GetResources',
+        containerPort: 3003,
+        handler: 'GetResourcesHandler.default',
+      },
     ]);
   });
 


### PR DESCRIPTION
There is a bug that environment variables are not injected properly to the containers when having multiple events(containers), because the container name contains the index `_${i}`. This PR fixes it.